### PR TITLE
Removing all references to CL5

### DIFF
--- a/docs/cagefs/README.md
+++ b/docs/cagefs/README.md
@@ -30,7 +30,7 @@ CageFS is not supported for H-Sphere.
 
 Minimum Requirements:
 
-* kernel: CL5 with lve0.8.54 or later, CL6 with lve1.2.17.1 or later, CL7.
+* kernel: CL6 with lve1.2.17.1 or later, CL7.
 * 7GB of disk space.
 
 Depending on your setup, and number of users, you might also need:

--- a/docs/cloudlinux_installation/README.md
+++ b/docs/cloudlinux_installation/README.md
@@ -142,13 +142,6 @@ You can download the latest CloudLinux ISO and use it to install CloudLinux on y
   * Last updated: July 05, 2018
 
 
-* **Latest stable CloudLinux 5.11 ISO (OBSOLETE)**:  
-
-  * x86_64 version: [http://repo.cloudlinux.com/cloudlinux/5.11/iso/x86_64/CloudLinux-5.11-x86_64-DVD.iso](http://repo.cloudlinux.com/cloudlinux/5.11/iso/x86_64/CloudLinux-5.11-x86_64-DVD.iso)
-  * i386 version: [http://repo.cloudlinux.com/cloudlinux/5.11/iso/i386/CloudLinux-5.11-i386-DVD.iso](http://repo.cloudlinux.com/cloudlinux/5.11/iso/i386/CloudLinux-5.11-i386-DVD.iso)
-  * Last updated: Oct 10, 2014
-
-
 :::tip Note
 Once you install server from the ISO, make sure you [register your system](/cloudlinux_installation/#registering-cloudlinux-server) and then run yum update.
 :::
@@ -224,7 +217,6 @@ It will boot into CloudLinux installer.
 
 2. During the CloudLinux installation select URL as installation source and enter URL: [http://repo.cloudlinux.com/cloudlinux/6.6/install/x86_64/](http://repo.cloudlinux.com/cloudlinux/6.6/install/x86_64/) and continue with installation.
 
-To install CloudLinux 5.10 instead of 6.6 use the following URL: [http://repo.cloudlinux.com/cloudlinux/5.10/netinstall/x86_64/](http://repo.cloudlinux.com/cloudlinux/5.10/netinstall/x86_64/)
 
 Same URLs can be used to install para-virtualized Xen using either command-line or virt manager.
 

--- a/docs/cloudlinux_life-cycle/README.md
+++ b/docs/cloudlinux_life-cycle/README.md
@@ -10,5 +10,3 @@ Currently Supported:
 |Operating System | Released | End of Life & Support|
 |CloudLinux 7 | Apr 1, 2015 | Jun 30, 2024|
 |CloudLinux 6 | Feb 1, 2011 | Nov 30, 2020|
-|CloudLinux 5 | Jan 1, 2010 | Mar 31, 2017|
-

--- a/docs/limits/README.md
+++ b/docs/limits/README.md
@@ -10,9 +10,9 @@ CloudLinux has support for the following limits:
 |[NCPU](/limits/#cpu-limits) [deprecated] | number of cores | 1 CORE | Max number of cores (smallest of <span class="notranslate"> CPU </span> & NCPU used) | all|
 |[PMEM](/limits/#memory-limits) | KB | 1024MB | Physical memory limit (RSS field in ps/RES in top). Also includes shared memory and disk cache | CL5 hybrid kernel, CL5 lve1.x+ kernel, CL6 and CL7|
 |[VMEM](/limits/#memory-limits) | KB | 0 | Virtual memory limit (VSZ field in ps/VIRT in top) | all|
-|[IO](/limits/#io) | KB/sec | 1024KB/sec | IO throughput - combines both read & write operations | CL7, CL6 lve1.1.9+ kernel, CL5 hybrid kernel|
-|IOPS [lve1.3+] | Operations per second | 1024 | Restricts total number of read/write operations per second. | CL7, CL6 and CL5 hybrid kernels lve1.3+|
-|[NPROC](/limits/#number-of-processes) | number | 100 | Max number of processes within LVE | CL5 hybrid kernel, CL5 lve1.x+ kernel, CL6 and CL7|
+|[IO](/limits/#io) | KB/sec | 1024KB/sec | IO throughput - combines both read & write operations | CL7, CL6 lve1.1.9+ kernel|
+|IOPS [lve1.3+] | Operations per second | 1024 | Restricts total number of read/write operations per second. | CL7 and CL6|
+|[NPROC](/limits/#number-of-processes) | number | 100 | Max number of processes within LVE | CL6 and CL7|
 |[EP](/limits/#entry-processes) | number | 20 | Limit on entry processes. Usually represents max number of concurrent connections to apache dynamic scripts as well as SSH and cron jobs running simultaneously. | all|
 
 ::: tip Note

--- a/docs/lve-stats_2/README.md
+++ b/docs/lve-stats_2/README.md
@@ -52,7 +52,6 @@ Settings of old <span class="notranslate">lve-stats</span> (ver. 0.x) are import
 
 SQLite database file is located in <span class="notranslate">`/var/lve/lvestats2.db`</span>, data from old <span class="notranslate">lve-stats</span> (ver. 0.x) are being migrated automatically in the background. Migrating process can last 2-8 hours (during this time lags are possible when admin is trying to check statistics, at the same time users will not be affected). Migrating the latest 30 days, <span class="notranslate">SQLite DB</span> stable migration is provided.
 
-Currently, the new <span class="notranslate">lve-stats</span> supports all databases available in CloudLinux (except <span class="notranslate">PosgreSQL</span> for CL5).
 
 ### Downgrade
 

--- a/docs/node_js_selector/README.md
+++ b/docs/node_js_selector/README.md
@@ -31,7 +31,7 @@
 #### **Requirements**
 
 * <span class="notranslate"> Node.js Selector </span>  supports Node.js versions 6.x, 8.x, 9.x and later.
-* This feature is available for CloudLinux 7, <span class="notranslate"> CloudLinux 6 hybridand CloudLinux 6. </span>
+* This feature is available for CloudLinux 7, <span class="notranslate"> CloudLinux 6 hybrid and CloudLinux 6. </span>
 * <span class="notranslate"> Node.js Selector requires LVE Manager 4.0 </span> or later.
 * It supports cPanel and DirectAdmin servers (Plesk is not supported as it already has Node.js support.) For more details, please go to Plesk & Node.js documentation [here](https://www.plesk.com/blog/product-technology/node-js-plesk-onyx/) and [here](https://docs.plesk.com/en-US/onyx/administrator-guide/website-management/nodejs-support.76652/) .
 * For more details about <span class="notranslate"> mod_passenger </span>  and Node.js, please read documentation  [here](https://www.phusionpassenger.com/library/walkthroughs/deploy/nodejs/)  and  [here](https://www.phusionpassenger.com/library/walkthroughs/deploy/nodejs/ownserver/apache/oss/el7/deploy_app.html) .


### PR DESCRIPTION
I was wondering if all the references to CL5 could be removed?