### PR TITLE
Update README.md

### DIFF
--- a/docs/control_panel_integration/README.md
+++ b/docs/control_panel_integration/README.md
@@ -520,7 +520,7 @@ If a reseller user or administrator user has a corresponding UNIX-user in the sy
 <div class="notranslate">
 
 ```
-/scripts/users --filter=id,email
+/scripts/users --fields=id,email
 ```
 </div>
 


### PR DESCRIPTION
Filter key for retrieving users is correctly written in the first usage example, but in the next example where data fields are specified, instead of key  '--fields' is written '--filter'.