### PR TITLE
Update in the Introduction section

### DIFF
--- a/docs/introduction/README.md
+++ b/docs/introduction/README.md
@@ -67,6 +67,7 @@ CloudLinux supports the same end-of-life policy as RHEL. Using a supported opera
 
 Currently supported:
 
+| |  | |
 |-|--|-|
 |Operating System | Released | End of Life & Support|
 |CloudLinux 8 | Mar 17, 2020 | TBA|

--- a/docs/introduction/README.md
+++ b/docs/introduction/README.md
@@ -67,11 +67,11 @@ CloudLinux supports the same end-of-life policy as RHEL. Using a supported opera
 
 Currently supported:
 
-| |  | |
 |-|--|-|
 |Operating System | Released | End of Life & Support|
+|CloudLinux 8 | Mar 17, 2020 | TBA|
 |CloudLinux 7 | Apr 1, 2015 | Jun 30, 2024|
-|CloudLinux 6 | Feb 1, 2011 | Nov 30, 2020|
-|CloudLinux 5 | Jan 1, 2010 | Mar 31, 2017|
+|CloudLinux 6 | Feb 1, 2011 | Nov 30, 2020 (Extended Support - June 30, 2024)|
 
+Read more about the Extended Support for ClouxLinux 6 [here](https://blog.cloudlinux.com/cloudlinux-6-extended-support-get-more-from-your-rhel/centos-6-investment).
 


### PR DESCRIPTION
!Please check if I fixed the line 69 right, there was an extra empty row in the table
https://docs.cloudlinux.com/introduction/#cloudlinux-os-lifecycle

Removed the CL OS 5 and added CL 8 to the list of supported OS. +extended support