### PR TITLE
LU-3681: cagefs_enter_user should remove temporary LVE id from ve.cfg and /proc/lve/list

### DIFF
--- a/docs/control_panel_integration/README.md
+++ b/docs/control_panel_integration/README.md
@@ -1196,6 +1196,10 @@ cagefs_enter_user --pmem=512M --speed=70% <user> <command>
 
 Refer to [documentation on limits](https://docs.cloudlinux.com/limits/#understanding-limits) for more details on the provided parameters.
 
+:::tip Note
+Temporary LVE is destroyed after the process terminates unless the option `--no-fork` passed.
+:::
+
 ### Updating CageFS skeleton
 
 Updating CageFS skeleton is required after update of the system RPM packages. It may be also required after update of hosting control panel itself.


### PR DESCRIPTION
Added a note that temporary LVE is not destroyed if the option '--no-fork' passed