### PR TITLE
Incorrect cloudlinux-top command

### DIFF
--- a/docs/command-line_tools/README.md
+++ b/docs/command-line_tools/README.md
@@ -540,7 +540,7 @@ Utility provides information about current MySQL and LVE usage of a running syst
 <div class="notranslate">
 
 ```
-cloudlinux_top [-h] [-v] [-j] [--hide-mysql]
+cloudlinux-top [-h] [-v] [-j] [--hide-mysql]
                [-u USERNAME | -r FOR_RESELLER] [-d DOMAIN] [-m MAX]
                [-o ORDER_BY]
 ```


### PR DESCRIPTION
# cloudlinux_top
-bash: cloudlinux_top: command not found