### PR TITLE
Added the 2 blank lines to the user_notify.txt example file.

### DIFF
--- a/docs/cloudlinux_os_components/README.md
+++ b/docs/cloudlinux_os_components/README.md
@@ -753,6 +753,8 @@ Example for the file <span class="notranslate">`user_notify.txt`</span>
 	
 ```
 Subject: Customized subject example
+	
+	
 Dear {{TONAME}},
  
 Your {{DOMAIN}} web hosting account exceeded one or more of its resources within the last {{PERIOD}}.


### PR DESCRIPTION
To change subject, in the very beginning of the file (no blank lines allowed in the beginning of the template) add the field Subject:, leave two blank lines after it and add template body. However, in the sample template, the 2 blank lines are not added: Example for the file user_notify.txt :
Subject: Customized subject example
Dear {{TONAME}},
 
Your {{DOMAIN}} web hosting account exceeded one or more of its resources within the last {{PERIOD}}.